### PR TITLE
Update get_tokens.js

### DIFF
--- a/get_tokens.js
+++ b/get_tokens.js
@@ -8,7 +8,7 @@ rl.question("Your application key: ", function(appKey) {
         var twitter = new twitterAPI({
             consumerKey: appKey,
             consumerSecret: appSecret,
-            callback: ''});
+            callback: 'oob'});//The value for oauth_callback must be set to oob during the POST oauth/request_token call.
         twitter.getRequestToken(function(error, requestToken,
                 requestTokenSecret, results) {
             console.log("Log into Twitter as the user you want to authorize " +


### PR DESCRIPTION
Changed callback to "oob" as per PIN-Based OAuth requirements:
"The value for oauth_callback must be set to oob during the POST oauth/request_token call." - https://developer.twitter.com/en/docs/authentication/oauth-1-0a/pin-based-oauth (Feb 09, 2022)

Doing so redirects to PIN instead of callback url.

Also, thanks for this example - very helpful!